### PR TITLE
Sql issue #1

### DIFF
--- a/llacie/db.py
+++ b/llacie/db.py
@@ -94,12 +94,12 @@ class LlacieDatabase(object):
                 table_name = match.group(2).strip('"')
                 tbl_chunks[table_name] = f"CREATE TABLE {sql_chunk}"
                 if match.group(1) is None: llacie_tables.append(table_name)
-                if inspect.has_table(table_name): # This checks if all tables exist, does not affect code but helps prevent "Creating table..." when it is not needed for missing-tables
+                if inspect.has_table(table_name):
                     existing_tables.append(table_name)
-                    
-            tables_to_drop = [tbl for tbl in llacie_tables if inspect.has_table(tbl)] # This prevents cohorts/episodes tables from being dropped. 
 
-            if not missing_tables_only and len(existing_tables) > 0:
+            # Existing tables other than cohorts and episodes are dropped if overwrite=True.       
+            tables_to_drop = [tbl for tbl in llacie_tables if inspect.has_table(tbl)]
+            if not missing_tables_only and len(tables_to_drop) > 0:
                 if not overwrite:
                     raise UsageError(f"Tables {', '.join(existing_tables)} already exist. If "
                         "you want to drop and create new blank tables, use --overwrite. "

--- a/llacie/db.py
+++ b/llacie/db.py
@@ -82,7 +82,7 @@ class LlacieDatabase(object):
         with open(sql_file) as f:
             sql = self.interpolate_config_vars(f.read())
             sql_chunks = re.split(r'^\s*CREATE TABLE\s+', sql, flags = re.MULTILINE)
-            
+            existing_tables = []
             tbl_chunks = OrderedDict()
             llacie_tables = []
             for sql_chunk in sql_chunks:
@@ -94,8 +94,11 @@ class LlacieDatabase(object):
                 table_name = match.group(2).strip('"')
                 tbl_chunks[table_name] = f"CREATE TABLE {sql_chunk}"
                 if match.group(1) is None: llacie_tables.append(table_name)
+                if inspect.has_table(table_name): # This checks if all tables exist, does not affect code but helps prevent "Creating table..." when it is not needed for missing-tables
+                    existing_tables.append(table_name)
+                    
+            tables_to_drop = [tbl for tbl in llacie_tables if inspect.has_table(tbl)] # This prevents cohorts/episodes tables from being dropped. 
 
-            existing_tables = [tbl for tbl in llacie_tables if inspect.has_table(tbl)]
             if not missing_tables_only and len(existing_tables) > 0:
                 if not overwrite:
                     raise UsageError(f"Tables {', '.join(existing_tables)} already exist. If "
@@ -103,7 +106,7 @@ class LlacieDatabase(object):
                         "If you only want to add missing tables, use --missing-tables-only.")
                 else:
                     # Existing tables are deleted in reverse order of creation
-                    for existing_table in reversed(existing_tables):
+                    for existing_table in reversed(tables_to_drop):
                         echo_info(f"Dropping existing table: {existing_table}")
                         self.conn.execute(text(f"DROP TABLE \"{existing_table}\""))
 

--- a/llacie/db.py
+++ b/llacie/db.py
@@ -82,7 +82,7 @@ class LlacieDatabase(object):
         with open(sql_file) as f:
             sql = self.interpolate_config_vars(f.read())
             sql_chunks = re.split(r'^\s*CREATE TABLE\s+', sql, flags = re.MULTILINE)
-            
+            existing_tables = []
             tbl_chunks = OrderedDict()
             llacie_tables = []
             for sql_chunk in sql_chunks:
@@ -90,12 +90,12 @@ class LlacieDatabase(object):
                 match = re.match(r'(IF +NOT +EXISTS +)?([a-zA-Z0-9_"]+) +[(]', sql_chunk)
                 if match is None: 
                     raise ConfigError("Invalid schema in sql/schema.sql")
-
                 table_name = match.group(2).strip('"')
                 tbl_chunks[table_name] = f"CREATE TABLE {sql_chunk}"
                 if match.group(1) is None: llacie_tables.append(table_name)
-
-            existing_tables = [tbl for tbl in llacie_tables if inspect.has_table(tbl)]
+                if inspect.has_table(table_name):   # Appends all tables if they exist, not relying on llacie_tables
+                    existing_tables.append(table_name) 
+            tables_to_drop = [tbl for tbl in llacie_tables if inspect.has_table(tbl)] # Excludes episodes and cohorts tables
             if not missing_tables_only and len(existing_tables) > 0:
                 if not overwrite:
                     raise UsageError(f"Tables {', '.join(existing_tables)} already exist. If "
@@ -103,7 +103,7 @@ class LlacieDatabase(object):
                         "If you only want to add missing tables, use --missing-tables-only.")
                 else:
                     # Existing tables are deleted in reverse order of creation
-                    for existing_table in reversed(existing_tables):
+                    for existing_table in reversed(tables_to_drop):
                         echo_info(f"Dropping existing table: {existing_table}")
                         self.conn.execute(text(f"DROP TABLE \"{existing_table}\""))
 

--- a/llacie/db.py
+++ b/llacie/db.py
@@ -82,7 +82,7 @@ class LlacieDatabase(object):
         with open(sql_file) as f:
             sql = self.interpolate_config_vars(f.read())
             sql_chunks = re.split(r'^\s*CREATE TABLE\s+', sql, flags = re.MULTILINE)
-            existing_tables = []
+            
             tbl_chunks = OrderedDict()
             llacie_tables = []
             for sql_chunk in sql_chunks:
@@ -90,12 +90,12 @@ class LlacieDatabase(object):
                 match = re.match(r'(IF +NOT +EXISTS +)?([a-zA-Z0-9_"]+) +[(]', sql_chunk)
                 if match is None: 
                     raise ConfigError("Invalid schema in sql/schema.sql")
+
                 table_name = match.group(2).strip('"')
                 tbl_chunks[table_name] = f"CREATE TABLE {sql_chunk}"
                 if match.group(1) is None: llacie_tables.append(table_name)
-                if inspect.has_table(table_name):   # Appends all tables if they exist, not relying on llacie_tables
-                    existing_tables.append(table_name) 
-            tables_to_drop = [tbl for tbl in llacie_tables if inspect.has_table(tbl)] # Excludes episodes and cohorts tables
+
+            existing_tables = [tbl for tbl in llacie_tables if inspect.has_table(tbl)]
             if not missing_tables_only and len(existing_tables) > 0:
                 if not overwrite:
                     raise UsageError(f"Tables {', '.join(existing_tables)} already exist. If "
@@ -103,7 +103,7 @@ class LlacieDatabase(object):
                         "If you only want to add missing tables, use --missing-tables-only.")
                 else:
                     # Existing tables are deleted in reverse order of creation
-                    for existing_table in reversed(tables_to_drop):
+                    for existing_table in reversed(existing_tables):
                         echo_info(f"Dropping existing table: {existing_table}")
                         self.conn.execute(text(f"DROP TABLE \"{existing_table}\""))
 

--- a/llacie/sql/schema.sql
+++ b/llacie/sql/schema.sql
@@ -8,18 +8,13 @@ CREATE TABLE IF NOT EXISTS "{{episode_table}}" (
 
 CREATE TABLE IF NOT EXISTS "{{cohort_table}}" (
     "id"                        BIGSERIAL PRIMARY KEY,
-    "FK_episode_id"             BIGINT NOT NULL,
+    "FK_episode_id"             BIGINT NOT NULL
+    REFERENCES "{{episode_table}}"("id")
+    ON DELETE RESTRICT ON UPDATE RESTRICT,
     "infectionCriteria"         BOOLEAN NOT NULL DEFAULT TRUE,
     "excl_ST0_combined"         BOOLEAN NOT NULL DEFAULT FALSE
 );
 
-ALTER TABLE "{{cohort_table}}" 
-    DROP CONSTRAINT IF EXISTS "{{cohort_table}}_FK_episode_id_fk",
-    ADD CONSTRAINT  "{{cohort_table}}_FK_episode_id_fk" 
-    FOREIGN KEY ("FK_episode_id")
-    REFERENCES "{{episode_table}}"("id")
-    ON DELETE RESTRICT
-    ON UPDATE RESTRICT;
 
 CREATE INDEX IF NOT EXISTS "{{cohort_table}}_FK_episode_id_key"
     ON "{{cohort_table}}" ("FK_episode_id");

--- a/llacie/sql/schema.sql
+++ b/llacie/sql/schema.sql
@@ -14,7 +14,8 @@ CREATE TABLE IF NOT EXISTS "{{cohort_table}}" (
 );
 
 ALTER TABLE "{{cohort_table}}" 
-    ADD CONSTRAINT "{{cohort_table}}_FK_episode_id_fk" 
+    DROP CONSTRAINT IF EXISTS "{{cohort_table}}_FK_episode_id_fk",
+    ADD CONSTRAINT  "{{cohort_table}}_FK_episode_id_fk" 
     FOREIGN KEY ("FK_episode_id")
     REFERENCES "{{episode_table}}"("id")
     ON DELETE RESTRICT

--- a/llacie/sql/schema.sql
+++ b/llacie/sql/schema.sql
@@ -10,16 +10,13 @@ CREATE TABLE IF NOT EXISTS "{{cohort_table}}" (
     "id"                        BIGSERIAL PRIMARY KEY,
     "FK_episode_id"             BIGINT NOT NULL,
     "infectionCriteria"         BOOLEAN NOT NULL DEFAULT TRUE,
-    "excl_ST0_combined"         BOOLEAN NOT NULL DEFAULT FALSE
+    "excl_ST0_combined"         BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT "{{cohort_table}}_FK_episode_id_fk"
+        FOREIGN KEY ("FK_episode_id")
+        REFERENCES "{{episode_table}}"("id")
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
 );
-
-ALTER TABLE "{{cohort_table}}" 
-    DROP CONSTRAINT IF EXISTS "{{cohort_table}}_FK_episode_id_fk",
-    ADD CONSTRAINT  "{{cohort_table}}_FK_episode_id_fk" 
-    FOREIGN KEY ("FK_episode_id")
-    REFERENCES "{{episode_table}}"("id")
-    ON DELETE RESTRICT
-    ON UPDATE RESTRICT;
 
 CREATE INDEX IF NOT EXISTS "{{cohort_table}}_FK_episode_id_key"
     ON "{{cohort_table}}" ("FK_episode_id");

--- a/llacie/sql/schema.sql
+++ b/llacie/sql/schema.sql
@@ -8,13 +8,18 @@ CREATE TABLE IF NOT EXISTS "{{episode_table}}" (
 
 CREATE TABLE IF NOT EXISTS "{{cohort_table}}" (
     "id"                        BIGSERIAL PRIMARY KEY,
-    "FK_episode_id"             BIGINT NOT NULL
-    REFERENCES "{{episode_table}}"("id")
-    ON DELETE RESTRICT ON UPDATE RESTRICT,
+    "FK_episode_id"             BIGINT NOT NULL,
     "infectionCriteria"         BOOLEAN NOT NULL DEFAULT TRUE,
     "excl_ST0_combined"         BOOLEAN NOT NULL DEFAULT FALSE
 );
 
+ALTER TABLE "{{cohort_table}}" 
+    DROP CONSTRAINT IF EXISTS "{{cohort_table}}_FK_episode_id_fk",
+    ADD CONSTRAINT  "{{cohort_table}}_FK_episode_id_fk" 
+    FOREIGN KEY ("FK_episode_id")
+    REFERENCES "{{episode_table}}"("id")
+    ON DELETE RESTRICT
+    ON UPDATE RESTRICT;
 
 CREATE INDEX IF NOT EXISTS "{{cohort_table}}_FK_episode_id_key"
     ON "{{cohort_table}}" ("FK_episode_id");


### PR DESCRIPTION
Fixes issue where tables can't be dropped by placing constraint when table is created.

Small changes to db.py that help prevent `creating... ` messages from printing when not needed when the `--missing-tables-only` flag is used.
Closes #1